### PR TITLE
Fix missing encodeHTML function

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ module.exports = function(content) {
   if (this.cacheable) {
     this.cacheable();
   }
+  
+  dot.templateSettings.selfcontained = true;
 
   var content = fs.readFileSync(this.resourcePath);
   return "module.exports = " + dot.template(content);


### PR DESCRIPTION
doT has a `{{! }}` operator which HTML encodes the interpolated values.
Using this feature fails unless either `templateSettings.selfcontained = true;`
or any code using the dot-loader also requires dot to get.

IMHO the latter is not in the spirit of webpack and introduces unnecessary
overhead for developers.