### PR TITLE
Bump doT to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "version": "0.1.0",
   "dependencies": {
-    "dot": "1.0.2"
+    "dot": "1.0.3"
   },
   "repository": "http://www.github.com/ross-pfahler/dot-loader",
   "licenses": [{


### PR DESCRIPTION
This PR bumps the `doT` dependency to latest 1.0.3 release