### PR TITLE
Make dot options available

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ var template = require("dot!./file.dot");
 module.exports = {
   module: {
     loaders: [
-      { test: /\.dot$/, loader: "dot-loader" }
+      {
+        test: /\.dot$/,
+        loader: "dot-loader",
+        options: {
+          // your custom dot options
+        }
+      }
     ]
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
 var dot = require('dot');
 var fs = require('fs');
+var loaderUtils = require('loader-utils');
 
 module.exports = function(content) {
+  var options = loaderUtils.getOptions(this);
   if (this.cacheable) {
     this.cacheable();
   }
-  
-  dot.templateSettings.selfcontained = true;
+
+  options.selfcontained = true;
+  dot.templateSettings = Object.assign(dot.templateSettings, options);
 
   var content = fs.readFileSync(this.resourcePath);
   return "module.exports = " + dot.template(content);

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "main": "index.js",
   "version": "0.1.1",
   "dependencies": {
-    "dot": "1.0.3"
+    "dot": "1.0.3",
+    "loader-utils": "^1.1.0"
   },
   "repository": "http://www.github.com/ross-pfahler/dot-loader",
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/mit-license.php"
-  }]
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ]
 }
-


### PR DESCRIPTION
I wrote this before noticing there's an old pull request that does a similar thing, but this one does try and use your own coding style.

Also updated the documentation. doT options just go in an `options` key in your loader.