### PR TITLE
fix:use origin file content

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,5 @@ module.exports = function(content) {
   options.selfcontained = true;
   dot.templateSettings = Object.assign(dot.templateSettings, options);
 
-  var content = fs.readFileSync(this.resourcePath);
   return "module.exports = " + dot.template(content);
 };


### PR DESCRIPTION
use orgin file content, so if someone want handle file content before pass to dot-loader